### PR TITLE
refactor: support per-method options in JSONRPC server

### DIFF
--- a/examples/rpcserver/main.go
+++ b/examples/rpcserver/main.go
@@ -19,6 +19,7 @@ func main() {
 			ServerName:         "public_server",
 			GetResponseContent: []byte("Hello world"),
 		},
+		nil,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Introduce `methodConfig` struct to encapsulate method handler and options.
- Add `MethodOpts` struct to define per-method options.
- Update `NewJSONRPCHandler` to accept method options and initialize `methodConfig`.
- Modify `ServeHTTP` to use per-method options for request signature verification, priority extraction, and origin extraction.
- Update tests to accommodate changes in handler initialization and method options.